### PR TITLE
Dockerize the app so it can run in Digger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:16 as build-deps
+WORKDIR /usr/src/app
+COPY package.json yarn.lock ./
+RUN yarn
+COPY . ./
+RUN yarn build
+
+FROM nginx:1.12-alpine
+COPY --from=build-deps /usr/src/app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Uses 2-step docker build process:

1. Build off the full official Node 16 image
2. Copy the bundle over into a lightweight Nginx image

This results in a small container that is quick to start

App working after building, tagging and running the docker image on localhost:80

<img width="1440" alt="Screenshot 2022-07-19 at 16 10 38" src="https://user-images.githubusercontent.com/1280498/179798951-ca69de82-2a52-41f8-b120-1e042de43f0d.png">
